### PR TITLE
Different MOTD on 1.15.2 and below

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>xyz.jpenilla</groupId>
     <artifactId>MiniMOTD</artifactId>
-    <version>1.1.2</version>
+    <version>1.1.3</version>
     <packaging>jar</packaging>
 
     <name>MiniMOTD</name>

--- a/src/main/java/xyz/jpenilla/minimotd/bungee/BungeeConfig.java
+++ b/src/main/java/xyz/jpenilla/minimotd/bungee/BungeeConfig.java
@@ -10,6 +10,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 
+import static xyz.jpenilla.minimotd.common.MiniMOTDConfig.Fields.MOTDSOLD;
+
 public class BungeeConfig extends MiniMOTDConfig {
     private final MiniMOTD miniMOTD;
 
@@ -25,6 +27,9 @@ public class BungeeConfig extends MiniMOTDConfig {
         for (String motd : config.getStringList(MOTDS)) {
             getMotds().add(motd.replace("{br}", "\n"));
         }
+        for (String motdOld : config.getStringList(MOTDSOLD)) {
+            getMotdsOld().add(motdOld.replace("{br}", "\n"));
+        }
         setMotdEnabled(config.getBoolean(MOTD_ENABLED));
         setMaxPlayersEnabled(config.getBoolean(MAX_PLAYERS_ENABLED));
         setJustXMoreEnabled(config.getBoolean(JUST_X_MORE_ENABLED));
@@ -33,6 +38,7 @@ public class BungeeConfig extends MiniMOTDConfig {
         setFakePlayersEnabled(config.getBoolean(FAKE_PLAYERS_ENABLED));
         setFakePlayers(config.getString(FAKE_PLAYERS));
     }
+
 
     private Configuration loadFromDisk() {
         if (!miniMOTD.getDataFolder().exists()) {

--- a/src/main/java/xyz/jpenilla/minimotd/bungee/MiniMOTD.java
+++ b/src/main/java/xyz/jpenilla/minimotd/bungee/MiniMOTD.java
@@ -7,6 +7,10 @@ import org.bstats.bungeecord.Metrics;
 public class MiniMOTD extends Plugin {
     @Getter private BungeeConfig cfg;
 
+    public BungeeConfig getCfg() {
+        return this.cfg;
+    }
+
     @Override
     public void onEnable() {
         this.cfg = new BungeeConfig(this);

--- a/src/main/java/xyz/jpenilla/minimotd/bungee/PingListener.java
+++ b/src/main/java/xyz/jpenilla/minimotd/bungee/PingListener.java
@@ -55,6 +55,10 @@ public class PingListener implements Listener {
                     Component motd = MiniMessage.get().parse(cfg.getMOTD(onlinePlayers, maxPlayers));
                     BaseComponent component = ComponentSerializer.parse(GsonComponentSerializer.builder().build().serialize(motd))[0];
                     response.setDescriptionComponent(component);
+                }else {
+                    Component motdOld = MiniMessage.get().parse(cfg.getMOTDOld(onlinePlayers, maxPlayers));
+                    BaseComponent component = ComponentSerializer.parse(GsonComponentSerializer.builder().build().serialize(motdOld))[0];
+                    response.setDescriptionComponent(component);
                 }
 
             }

--- a/src/main/java/xyz/jpenilla/minimotd/bungee/PingListener.java
+++ b/src/main/java/xyz/jpenilla/minimotd/bungee/PingListener.java
@@ -51,10 +51,12 @@ public class PingListener implements Listener {
             players.setMax(maxPlayers);
 
             if (cfg.isMotdEnabled()) {
-                Component motd = MiniMessage.get().parse(cfg.getMOTD(onlinePlayers, maxPlayers));
-                BaseComponent component = ComponentSerializer.parse(GsonComponentSerializer.builder().build().serialize(motd))[0];
-                response.setDescriptionComponent(component);
-                //response.setDescriptionComponent(BungeeCordComponentSerializer.get().serialize(motd)[0]);
+                if (e.getConnection().getVersion() >= 735) {
+                    Component motd = MiniMessage.get().parse(cfg.getMOTD(onlinePlayers, maxPlayers));
+                    BaseComponent component = ComponentSerializer.parse(GsonComponentSerializer.builder().build().serialize(motd))[0];
+                    response.setDescriptionComponent(component);
+                }
+
             }
 
             response.setPlayers(players);

--- a/src/main/java/xyz/jpenilla/minimotd/common/MiniMOTDConfig.java
+++ b/src/main/java/xyz/jpenilla/minimotd/common/MiniMOTDConfig.java
@@ -144,14 +144,18 @@ public abstract class MiniMOTDConfig {
 
     public String getMOTD(int onlinePlayers, int maxPlayers) {
         if (this.motds.size() == 1)
-            return this.motds.get(0);
+            return this.motds.get(0)
+                    .replace("{onlinePlayers}", String.valueOf(onlinePlayers))
+                    .replace("{maxPlayers}", String.valueOf(maxPlayers));
         return ((String)this.motds.get((new Random()).nextInt(this.motds.size())))
                 .replace("{onlinePlayers}", String.valueOf(onlinePlayers))
                 .replace("{maxPlayers}", String.valueOf(maxPlayers));
     }
     public String getMOTDOld(int onlinePlayers, int maxPlayers) {
         if (this.motdsOld.size() == 1)
-            return this.motdsOld.get(0);
+            return this.motdsOld.get(0)
+                    .replace("{onlinePlayers}", String.valueOf(onlinePlayers))
+                    .replace("{maxPlayers}", String.valueOf(maxPlayers));
         return ((String)this.motdsOld.get((new Random()).nextInt(this.motdsOld.size())))
                 .replace("{onlinePlayers}", String.valueOf(onlinePlayers))
                 .replace("{maxPlayers}", String.valueOf(maxPlayers));

--- a/src/main/java/xyz/jpenilla/minimotd/common/MiniMOTDConfig.java
+++ b/src/main/java/xyz/jpenilla/minimotd/common/MiniMOTDConfig.java
@@ -7,6 +7,8 @@ public abstract class MiniMOTDConfig {
     public static final class Fields {
         public static final String MOTDS = "MOTDS";
 
+        public static final String MOTDSOLD = "MOTDSOLD";
+
         public static final String MOTD_ENABLED = "MOTD_ENABLED";
 
         public static final String MAX_PLAYERS_ENABLED = "MAX_PLAYERS_ENABLED";
@@ -22,6 +24,8 @@ public abstract class MiniMOTDConfig {
         public static final String FAKE_PLAYERS = "FAKE_PLAYERS";
 
         public static final String motds = "motds";
+
+        public static final String motdsOld = "motdsOld";
 
         public static final String motdEnabled = "motdEnabled";
 
@@ -40,6 +44,8 @@ public abstract class MiniMOTDConfig {
 
     public final String MOTDS = "motd.motds";
 
+    public final String MOTDSOLD = "motd.motdsOld";
+
     public final String MOTD_ENABLED = "motd.motdEnabled";
 
     public final String MAX_PLAYERS_ENABLED = "maxPlayers.maxPlayersEnabled";
@@ -55,6 +61,9 @@ public abstract class MiniMOTDConfig {
     public final String FAKE_PLAYERS = "bungeeOnly.fakePlayers";
 
     private final ArrayList<String> motds = new ArrayList<>();
+
+    private final ArrayList<String> motdsOld = new ArrayList<>();
+
 
     private boolean motdEnabled;
 
@@ -72,6 +81,9 @@ public abstract class MiniMOTDConfig {
 
     public ArrayList<String> getMotds() {
         return this.motds;
+    }
+    public ArrayList<String> getMotdsOld() {
+        return this.motdsOld;
     }
 
     public boolean isMotdEnabled() {
@@ -134,6 +146,13 @@ public abstract class MiniMOTDConfig {
         if (this.motds.size() == 1)
             return this.motds.get(0);
         return ((String)this.motds.get((new Random()).nextInt(this.motds.size())))
+                .replace("{onlinePlayers}", String.valueOf(onlinePlayers))
+                .replace("{maxPlayers}", String.valueOf(maxPlayers));
+    }
+    public String getMOTDOld(int onlinePlayers, int maxPlayers) {
+        if (this.motdsOld.size() == 1)
+            return this.motdsOld.get(0);
+        return ((String)this.motdsOld.get((new Random()).nextInt(this.motdsOld.size())))
                 .replace("{onlinePlayers}", String.valueOf(onlinePlayers))
                 .replace("{maxPlayers}", String.valueOf(maxPlayers));
     }

--- a/src/main/java/xyz/jpenilla/minimotd/common/MiniMOTDConfig.java
+++ b/src/main/java/xyz/jpenilla/minimotd/common/MiniMOTDConfig.java
@@ -1,48 +1,148 @@
 package xyz.jpenilla.minimotd.common;
 
-import lombok.Getter;
-import lombok.Setter;
-import lombok.experimental.FieldNameConstants;
-
 import java.util.ArrayList;
 import java.util.Random;
 
-@FieldNameConstants
 public abstract class MiniMOTDConfig {
-    public final String MOTDS = "motd." + Fields.motds;
-    public final String MOTD_ENABLED = "motd." + Fields.motdEnabled;
-    public final String MAX_PLAYERS_ENABLED = Fields.maxPlayers + "." + Fields.maxPlayersEnabled;
-    public final String JUST_X_MORE_ENABLED = Fields.maxPlayers + "." + Fields.justXMoreEnabled;
-    public final String MAX_PLAYERS = Fields.maxPlayers + "." + Fields.maxPlayers;
-    public final String X_VALUE = Fields.maxPlayers + "." + Fields.xValue;
-    public final String FAKE_PLAYERS_ENABLED = "bungeeOnly." + Fields.fakePlayersEnabled;
-    public final String FAKE_PLAYERS = "bungeeOnly." + Fields.fakePlayers;
-    @Getter private final ArrayList<String> motds = new ArrayList<>();
-    @Getter @Setter private boolean motdEnabled;
-    @Getter @Setter private boolean maxPlayersEnabled;
-    @Getter @Setter private boolean justXMoreEnabled;
-    @Getter @Setter private boolean fakePlayersEnabled;
-    @Getter @Setter private int xValue;
-    @Getter @Setter private int maxPlayers;
-    @Getter @Setter private String fakePlayers;
+    public static final class Fields {
+        public static final String MOTDS = "MOTDS";
 
-    public abstract void reload();
+        public static final String MOTD_ENABLED = "MOTD_ENABLED";
+
+        public static final String MAX_PLAYERS_ENABLED = "MAX_PLAYERS_ENABLED";
+
+        public static final String JUST_X_MORE_ENABLED = "JUST_X_MORE_ENABLED";
+
+        public static final String MAX_PLAYERS = "MAX_PLAYERS";
+
+        public static final String X_VALUE = "X_VALUE";
+
+        public static final String FAKE_PLAYERS_ENABLED = "FAKE_PLAYERS_ENABLED";
+
+        public static final String FAKE_PLAYERS = "FAKE_PLAYERS";
+
+        public static final String motds = "motds";
+
+        public static final String motdEnabled = "motdEnabled";
+
+        public static final String maxPlayersEnabled = "maxPlayersEnabled";
+
+        public static final String justXMoreEnabled = "justXMoreEnabled";
+
+        public static final String fakePlayersEnabled = "fakePlayersEnabled";
+
+        public static final String xValue = "xValue";
+
+        public static final String maxPlayers = "maxPlayers";
+
+        public static final String fakePlayers = "fakePlayers";
+    }
+
+    public final String MOTDS = "motd.motds";
+
+    public final String MOTD_ENABLED = "motd.motdEnabled";
+
+    public final String MAX_PLAYERS_ENABLED = "maxPlayers.maxPlayersEnabled";
+
+    public final String JUST_X_MORE_ENABLED = "maxPlayers.justXMoreEnabled";
+
+    public final String MAX_PLAYERS = "maxPlayers.maxPlayers";
+
+    public final String X_VALUE = "maxPlayers.xValue";
+
+    public final String FAKE_PLAYERS_ENABLED = "bungeeOnly.fakePlayersEnabled";
+
+    public final String FAKE_PLAYERS = "bungeeOnly.fakePlayers";
+
+    private final ArrayList<String> motds = new ArrayList<>();
+
+    private boolean motdEnabled;
+
+    private boolean maxPlayersEnabled;
+
+    private boolean justXMoreEnabled;
+
+    private boolean fakePlayersEnabled;
+
+    private int xValue;
+
+    private int maxPlayers;
+
+    private String fakePlayers;
+
+    public ArrayList<String> getMotds() {
+        return this.motds;
+    }
+
+    public boolean isMotdEnabled() {
+        return this.motdEnabled;
+    }
+
+    public void setMotdEnabled(boolean motdEnabled) {
+        this.motdEnabled = motdEnabled;
+    }
+
+    public boolean isMaxPlayersEnabled() {
+        return this.maxPlayersEnabled;
+    }
+
+    public void setMaxPlayersEnabled(boolean maxPlayersEnabled) {
+        this.maxPlayersEnabled = maxPlayersEnabled;
+    }
+
+    public boolean isJustXMoreEnabled() {
+        return this.justXMoreEnabled;
+    }
+
+    public void setJustXMoreEnabled(boolean justXMoreEnabled) {
+        this.justXMoreEnabled = justXMoreEnabled;
+    }
+
+    public boolean isFakePlayersEnabled() {
+        return this.fakePlayersEnabled;
+    }
+
+    public void setFakePlayersEnabled(boolean fakePlayersEnabled) {
+        this.fakePlayersEnabled = fakePlayersEnabled;
+    }
+
+    public int getXValue() {
+        return this.xValue;
+    }
+
+    public void setXValue(int xValue) {
+        this.xValue = xValue;
+    }
+
+    public int getMaxPlayers() {
+        return this.maxPlayers;
+    }
+
+    public void setMaxPlayers(int maxPlayers) {
+        this.maxPlayers = maxPlayers;
+    }
+
+    public String getFakePlayers() {
+        return this.fakePlayers;
+    }
+
+    public void setFakePlayers(String fakePlayers) {
+        this.fakePlayers = fakePlayers;
+    }
 
     public String getMOTD(int onlinePlayers, int maxPlayers) {
-        if (motds.size() == 1) {
-            return motds.get(0);
-        } else {
-            return motds.get(new Random().nextInt(motds.size()))
-                    .replace("{onlinePlayers}", String.valueOf(onlinePlayers))
-                    .replace("{maxPlayers}", String.valueOf(maxPlayers));
-        }
+        if (this.motds.size() == 1)
+            return this.motds.get(0);
+        return ((String)this.motds.get((new Random()).nextInt(this.motds.size())))
+                .replace("{onlinePlayers}", String.valueOf(onlinePlayers))
+                .replace("{maxPlayers}", String.valueOf(maxPlayers));
     }
 
     public int getAdjustedMaxPlayers(int onlinePlayers, int actualMaxPlayers) {
-        if (maxPlayersEnabled) {
-            return justXMoreEnabled ? onlinePlayers + xValue : maxPlayers;
-        } else {
-            return actualMaxPlayers;
-        }
+        if (this.maxPlayersEnabled)
+            return this.justXMoreEnabled ? (onlinePlayers + this.xValue) : this.maxPlayers;
+        return actualMaxPlayers;
     }
+
+    public abstract void reload();
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -8,6 +8,10 @@ motd:
   motds:
     - "<bold><gradient:black:white>----====[</gradient> <gradient:green:blue>UltraCraft <gradient:red:yellow></bold><italic>Official</gradient></italic><bold> <gradient:white:black>]=====----</gradient></bold>{br}<bold>    <gradient:#EEFF4A:#F7FFAE>Custom <italic>Survival</italic></gradient>    <color:#0092FF>Discord</bold><gray>:</gray> <gradient:#5FDAFF:#B8A6FF><italic>Ab3d5f"
     - "<rainbow>|||||||||||||||||||||||||||||||||||||||||||||||||||||||||</rainbow>{br}<white>Hello <blue>{onlinePlayers} <gray>/</gray> {maxPlayers}</blue> Players Online"
+  motdsOld:
+    - "<red>This server requires version 1.16+"
+    - "<green>Sample motd displayed on version 1.15.2 and below"
+    - "<red>This function only works on bungeecord/waterfall servers!"
 
 maxPlayers:
   # Do you want to enable this feature?


### PR DESCRIPTION
Since 1.15.2 doesn't support RGB, motd is not displayed correctly in versions older than 1.16. 
It only works on bungeecord servers, since spigot doesn't have a way to check version easily